### PR TITLE
Update ctr_pthread.h

### DIFF
--- a/src/ctr_pthread.h
+++ b/src/ctr_pthread.h
@@ -40,12 +40,16 @@ extern "C" {
 
 #define STACKSIZE (4 * 1024)
 
+#ifndef PTHREAD_SCOPE_PROCESS
+/* An earlier version of devkitARM does not define the pthread types. Can remove in r54+. */
+
 typedef Thread     pthread_t;
 typedef LightLock  pthread_mutex_t;
 typedef void*      pthread_mutexattr_t;
 typedef int        pthread_attr_t;
 typedef LightEvent pthread_cond_t;
 typedef int        pthread_condattr_t;
+#endif
 
 /* libctru threads return void but pthreads return void pointer */
 static bool mutex_inited = false;
@@ -85,19 +89,19 @@ static INLINE int pthread_create(pthread_t *thread,
 	   return EAGAIN;
    }
 
-   *thread = new_ctr_thread;
+   *thread = (pthread_t)new_ctr_thread;
    return 0;
 }
 
 static INLINE pthread_t pthread_self(void)
 {
-   return threadGetCurrent();
+   return (pthread_t)threadGetCurrent();
 }
 
 static INLINE int pthread_mutex_init(pthread_mutex_t *mutex,
       const pthread_mutexattr_t *attr)
 {
-   LightLock_Init(mutex);
+   LightLock_Init((LightLock *)mutex);
    return 0;
 }
 
@@ -109,12 +113,12 @@ static INLINE int pthread_mutex_destroy(pthread_mutex_t *mutex)
 
 static INLINE int pthread_mutex_lock(pthread_mutex_t *mutex)
 {
-   return LightLock_TryLock(mutex);
+   return LightLock_TryLock((LightLock *)mutex);
 }
 
 static INLINE int pthread_mutex_unlock(pthread_mutex_t *mutex)
 {
-   LightLock_Unlock(mutex);
+   LightLock_Unlock((LightLock *)mutex);
    return 0;
 }
 
@@ -135,37 +139,37 @@ static INLINE int pthread_detach(pthread_t thread)
 static INLINE int pthread_join(pthread_t thread, void **retval)
 {
    /*retval is ignored*/
-   return threadJoin(thread, U64_MAX);
+   return threadJoin((Thread)thread, U64_MAX);
 }
 
 static INLINE int pthread_mutex_trylock(pthread_mutex_t *mutex)
 {
-   return LightLock_TryLock(mutex);
+   return LightLock_TryLock((LightLock *)mutex);
 }
 
 static INLINE int pthread_cond_wait(pthread_cond_t *cond,
       pthread_mutex_t *mutex)
 {
-   LightEvent_Wait(cond);
+   LightEvent_Wait((LightEvent *)cond);
    return 0;
 }
 
 static INLINE int pthread_cond_init(pthread_cond_t *cond,
       const pthread_condattr_t *attr)
 {
-   LightEvent_Init(cond, RESET_ONESHOT);
+   LightEvent_Init((LightEvent *)cond, RESET_ONESHOT);
    return 0;
 }
 
 static INLINE int pthread_cond_signal(pthread_cond_t *cond)
 {
-   LightEvent_Signal(cond);
+   LightEvent_Signal((LightEvent *)cond);
    return 0;
 }
 
 static INLINE int pthread_cond_broadcast(pthread_cond_t *cond)
 {
-   LightEvent_Signal(cond);
+   LightEvent_Signal((LightEvent *)cond);
    return 0;
 }
 
@@ -177,7 +181,7 @@ static INLINE int pthread_cond_destroy(pthread_cond_t *cond)
 
 static INLINE int pthread_equal(pthread_t t1, pthread_t t2)
 {
-	if (threadGetHandle(t1) == threadGetHandle(t2))
+	if (threadGetHandle((Thread)t1) == threadGetHandle((Thread)t2))
 		return 1;
 	return 0;
 }


### PR DESCRIPTION
The libretro-toolchain version of devkitARM (maybe newlib?) incorrectly prevents `_pthreadtypes.h` from being included. Newer versions include it.

In order to make a version of ctr_pthread.h that works under both old and new toolchains, the typedefs are guarded by a define in `_pthreadtypes.h` that is only active if the other types are defined.

I've also added casts in order to make sure this compiles correctly with the standard pthread.h type definitions.

This successfully builds under both the version of devkitARM in libretro-toolchains and the newest devkitARM.