### PR TITLE
Update .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,6 +108,8 @@ android-arm64-v8a:
   extends:
     - .libretro-android-cmake-arm64-v8a
     - .core-defs
+  variables:
+    NDK_ROOT: /android-sdk-linux/ndk/26.2.11394342
 
 # Android 64-bit x86
 android-x86_64:


### PR DESCRIPTION
Ok, the whole horrible chain of events was:

* Someone pointed out that some cmake gitlab CI template files were not setting `-DCMAKE_BUILD_TYPE=Release`, including for android
* I added it
* This broke the android build for ThePowderToy because the 22.0 NDK was crashing during one of the optimization passes
* In the android cmake gitlab CI template file I bumped the NDK version to 26.2
* This broke flycast's dynarec for reasons I don't understand nor have capacity to debug
* I've reverted the android cmake gitlab template file NDK bump, this again breaks ThePowderToy

https://git.libretro.com/libretro/ThePowderToy/-/pipelines/10209